### PR TITLE
cmake: Enable -mtune=haswell

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ if(CABLE_COMPILER_GNULIKE)
     cable_add_cxx_compiler_flag_if_supported(-Wsuggest-destructor-override)
     cable_add_cxx_compiler_flag_if_supported(-Wunreachable-code-break)
 
+    # The -mtune=generic does not work well yet in current compilers.
+    # Pick a good baseline for tuning.
+    cable_add_cxx_compiler_flag_if_supported(-mtune=haswell)
+
     if(CABLE_COMPILER_CLANG)
         set(CMAKE_CXX_FLAGS_COVERAGE "-fprofile-instr-generate -fcoverage-mapping")
     elseif(CABLE_COMPILER_GNU)


### PR DESCRIPTION
The -mtune=generic is not default although some sources claim it is. Besides the generic target is too low in current compilers. Use haswell for instruction tuning which should match x86-64-v3 architecture (unfortunately, the -mtune=x86-64-v3 is not supported).